### PR TITLE
Make /getassignments accessible to all group members

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,7 +167,7 @@ def create_assignment_reply(message, user_id):
         logging.error(e)
 
 
-@bot.message_handler(commands=['getassignments'], func=lambda message: message.chat.type == "group")
+@bot.message_handler(commands=['getassignments'], func=lambda message: message.chat.type in ["supergroup", "group"])
 def list_assignments(message):
     # HACK HANDLE PAGINATION
     ASSIGNMENTS_LIST = assignments_ref.get()
@@ -178,7 +178,7 @@ def list_assignments(message):
     else:
         bot.send_message(message.chat.id, "No assignments found.")
 
-@bot.message_handler(commands=['manageassignments'], func=lambda message: message.chat.type == "group")
+@bot.message_handler(commands=['manageassignments'], func=lambda message: message.chat.type  in ["supergroup", "group"])
 def manage_assignments(message):
     if (message.from_user.id not in [admin.user.id for admin in bot.get_chat_administrators(message.chat.id)]):
         bot.reply_to(message, "You must be an admin to edit assignments.")

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,39 @@
+from typing import List
+
+
+def assignment_to_text(assignment: dict) -> str:
+    """Returns a string representatin of an assignment in the following text format
+
+    Course Code: code
+    Title: title
+    Description: description
+    Due Date: due date
+    """
+
+    assignment_format = (
+        "*Course Code*: {course_code}\n"
+        "*Title*: {title}\n"
+        "*Description*: {description}\n"
+        "*Due Date*: {due_date}"
+    )
+
+    format_args = {
+        "course_code": assignment["course_code"],
+        "title": assignment["title"],
+        "description": assignment["description"],
+        "due_date": assignment["deadline"]
+    }
+
+    return assignment_format.format(**format_args)
+
+
+def generate_get_assignments_message(assignments: List[dict]) -> str:
+    """Formats and returns the get assignments response message"""
+    # format assignments as text
+    message_format = ("Hey 👋, here's a quick rundown of your pending assignments: \n\n"
+                      "{assignment_section}")
+
+    assignments_as_text = [assignment_to_text(ass) for ass in assignments]
+    assignment_section = "\n\n".join(assignments_as_text)
+
+    return message_format.format(assignment_section=assignment_section)


### PR DESCRIPTION
<h1>Make /getassignments accessible to all group members</h1>

Resolves #5 

- [X] Created a new command called `/manageassignments` with the current functionality of the `/getassignments` command. Group admins will use this command to manage assignements.

- [X] Extended the functionality of the `/getassignments` command to allow all group members, including non-administrators, to view assignments.

- [X] Fixed a bug that prevented `/getassignments` and `/manageassignments`  from working in supergroups. Prior to this PR, these commands only functioned in regular telegram groups i.e `message.chat.type == "group"`

- [X] Removed inline buttons and simpliflied the assignment listings into a single message. See below


```
Hey 👋, here's a quick rundown of your pending assignments: 

Subject: [Subject Name 2]
Assignment: [Assignment Name 2]
Due Date: [Due Date 2]


Subject: [Subject Name 3]
Assignment: [Assignment Name 3]
Due Date: [Due Date 3]
```
